### PR TITLE
Simplification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4.26"

--- a/src/model/events.rs
+++ b/src/model/events.rs
@@ -1,5 +1,3 @@
-use chrono::Duration;
-
 use crate::utils;
 
 use super::{
@@ -10,7 +8,6 @@ use super::{
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Event {
     pub id: u64,
-    pub length: Duration,
     // This is Some(slot) if the event is always supposed to be in one particular slot.
     pub fixed_slot: Option<Slot>,
     // This is Some if there are any constraints on resources, None if they can be
@@ -20,27 +17,22 @@ pub struct Event {
     pub time_constraints: Option<Outline>,
     // This makes it rather easy to specify the repeats (e.g. daily, weekly,...).
     // If None, then event occurs only once.
-    pub repeat_duration: Option<Duration>,
     pub tags: Vec<u64>,
 }
 
 impl Event {
     pub fn new(
         id: u64,
-        length: Duration,
         fixed_slot: Option<Slot>,
         resource_constraints: Option<Vec<Resource>>,
         time_constraints: Option<Outline>,
-        repeat_duration: Option<Duration>,
         tags: Vec<u64>,
     ) -> Event {
         Event {
             id,
-            length,
             fixed_slot,
             resource_constraints,
             time_constraints,
-            repeat_duration,
             tags,
         }
     }
@@ -62,23 +54,19 @@ impl Event {
 
 pub struct EventBuilder {
     id: u64,
-    length: Duration,
     fixed_slot: Option<Slot>,
     resource_constraints: Option<Vec<Resource>>,
     time_constraints: Option<Outline>,
-    repeat_duration: Option<Duration>,
     tags: Vec<u64>,
 }
 
 impl EventBuilder {
-    pub fn new(id: u64, length: Duration) -> EventBuilder {
+    pub fn new(id: u64) -> EventBuilder {
         EventBuilder {
             id: id,
-            length: length,
             fixed_slot: None,
             resource_constraints: None,
             time_constraints: None,
-            repeat_duration: None,
             tags: vec![],
         }
     }
@@ -98,11 +86,6 @@ impl EventBuilder {
         self
     }
 
-    pub fn repeat_duration(mut self, duration: Duration) -> EventBuilder {
-        self.repeat_duration = Some(duration);
-        self
-    }
-
     pub fn tags(mut self, tags: Vec<u64>) -> EventBuilder {
         self.tags = tags;
         self
@@ -111,11 +94,9 @@ impl EventBuilder {
     pub fn build(self) -> Event {
         Event {
             id: self.id,
-            length: self.length,
             fixed_slot: self.fixed_slot,
             resource_constraints: self.resource_constraints,
             time_constraints: self.time_constraints,
-            repeat_duration: self.repeat_duration,
             tags: self.tags,
         }
     }

--- a/src/model/events.rs
+++ b/src/model/events.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash, ops::Deref};
+use std::{collections::HashMap, ops::Deref};
 
 use crate::utils::{self, has_unique_items};
 
@@ -78,22 +78,22 @@ impl EventBuilder {
         }
     }
 
-    pub fn fixed_slot(mut self, slot: Slot) -> EventBuilder {
+    pub fn fixed_slot(mut self, slot: Slot) -> Self {
         self.fixed_slot = Some(slot);
         self
     }
 
-    pub fn resource_constraints(mut self, constraints: Vec<Resource>) -> EventBuilder {
+    pub fn resource_constraints(mut self, constraints: Vec<Resource>) -> Self {
         self.resource_constraints = Some(constraints);
         self
     }
 
-    pub fn time_constraints(mut self, constraints: Outline) -> EventBuilder {
+    pub fn time_constraints(mut self, constraints: Outline) -> Self {
         self.time_constraints = Some(constraints);
         self
     }
 
-    pub fn tags(mut self, tags: Vec<u64>) -> EventBuilder {
+    pub fn tags(mut self, tags: Vec<u64>) -> Self {
         self.tags = tags;
         self
     }
@@ -124,6 +124,7 @@ impl Schedule {
     pub fn new(event_instances: Vec<EventInstance>) -> Result<Schedule, ()> {
         let mut map: HashMap<Slot, Vec<Resource>> = HashMap::new();
 
+        // This check ensures that no two EventInstances use the same resources in the same slot
         for ei in event_instances.iter() {
             let key: &Slot = &ei.deref().assigned_slot;
 

--- a/src/model/slots.rs
+++ b/src/model/slots.rs
@@ -1,6 +1,4 @@
-use chrono::{DateTime, Duration, Utc};
-
-use crate::utils::{self, has_unique_items};
+use crate::utils::has_unique_items;
 
 use super::events::EventInstance;
 

--- a/src/model/slots.rs
+++ b/src/model/slots.rs
@@ -2,7 +2,7 @@ use crate::utils::has_unique_items;
 
 use super::events::EventInstance;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub struct Slot {
     id: i64,
 }
@@ -10,22 +10,6 @@ pub struct Slot {
 impl Slot {
     pub fn new(id: i64) -> Slot {
         Slot { id }
-    }
-
-    pub fn populate(self, event_instances: Vec<EventInstance>) -> Result<PopulatedSlot, ()> {
-        let folded = event_instances.iter().fold(vec![], |mut acc, x| {
-            acc.extend_from_slice(x.assigned_resources.as_slice());
-            acc
-        });
-
-        if !has_unique_items(folded) {
-            return Err(());
-        }
-
-        Ok(PopulatedSlot {
-            slot: self,
-            event_instances: event_instances,
-        })
     }
 }
 
@@ -47,21 +31,5 @@ impl Outline {
 impl From<Vec<Slot>> for Outline {
     fn from(value: Vec<Slot>) -> Self {
         Outline { slots: value }
-    }
-}
-
-#[derive(Clone)]
-pub struct PopulatedSlot {
-    pub slot: Slot,
-    pub event_instances: Vec<EventInstance>,
-}
-
-pub struct Schedule {
-    pub populated_slots: Vec<PopulatedSlot>,
-}
-
-impl Schedule {
-    pub fn new(populated_slots: Vec<PopulatedSlot>) -> Schedule {
-        Schedule { populated_slots }
     }
 }

--- a/src/model/slots.rs
+++ b/src/model/slots.rs
@@ -6,17 +6,12 @@ use super::events::EventInstance;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Slot {
-    pub start: DateTime<Utc>,
-    pub end: DateTime<Utc>,
+    id: i64,
 }
 
 impl Slot {
-    pub fn new(start: DateTime<Utc>, end: DateTime<Utc>) -> Slot {
-        Slot { start, end }
-    }
-
-    pub fn length(&self) -> Duration {
-        self.end.signed_duration_since(self.start)
+    pub fn new(id: i64) -> Slot {
+        Slot { id }
     }
 
     pub fn populate(self, event_instances: Vec<EventInstance>) -> Result<PopulatedSlot, ()> {

--- a/src/model/slots.rs
+++ b/src/model/slots.rs
@@ -1,7 +1,3 @@
-use crate::utils::has_unique_items;
-
-use super::events::EventInstance;
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub struct Slot {
     id: i64,

--- a/src/tests/example_tests.rs
+++ b/src/tests/example_tests.rs
@@ -1,7 +1,0 @@
-use super::super::*;
-
-#[test]
-fn it_works() {
-    let result: usize = add(2, 2);
-    assert_eq!(result, 4);
-}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,2 +1,1 @@
-pub mod example_tests;
 pub mod model_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,2 @@
 pub mod example_tests;
+pub mod model_tests;

--- a/src/tests/model_tests.rs
+++ b/src/tests/model_tests.rs
@@ -9,22 +9,10 @@ use crate::model::{
 #[test]
 pub fn event_errors_with_wrong_constraints() {
     let event = EventBuilder::new(1, Duration::minutes(30))
-        .resource_constraints(vec![Resource::new(
-            1,
-            Outline::from(vec![Slot::new(
-                Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
-                Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
-            )]),
-        )])
+        .resource_constraints(vec![Resource::new(1, Outline::from(vec![Slot::new(1)]))])
         .build();
 
-    let res = event.assign(vec![Resource::new(
-        2,
-        Outline::from(vec![Slot::new(
-            Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
-            Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
-        )]),
-    )]);
+    let res = event.assign(vec![Resource::new(2, Outline::from(vec![Slot::new(2)]))]);
 
     assert_eq!(res, Err(()));
 }
@@ -32,34 +20,18 @@ pub fn event_errors_with_wrong_constraints() {
 #[test]
 pub fn event_assigns_with_constraints() {
     let event = EventBuilder::new(1, Duration::minutes(30))
-        .resource_constraints(vec![Resource::new(
-            1,
-            Outline::from(vec![Slot::new(
-                Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
-                Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
-            )]),
-        )])
+        .resource_constraints(vec![Resource::new(1, Outline::from(vec![Slot::new(1)]))])
         .build();
 
-    let res = event.clone().assign(vec![Resource::new(
-        1,
-        Outline::from(vec![Slot::new(
-            Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
-            Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
-        )]),
-    )]);
+    let res = event
+        .clone()
+        .assign(vec![Resource::new(1, Outline::from(vec![Slot::new(1)]))]);
 
     assert_eq!(
         res,
         Ok(EventInstance {
             event: event,
-            assigned_resources: vec![Resource::new(
-                1,
-                Outline::from(vec![Slot::new(
-                    Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
-                    Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
-                )],)
-            )],
+            assigned_resources: vec![Resource::new(1, Outline::from(vec![Slot::new(1)],))],
         })
     );
 }

--- a/src/tests/model_tests.rs
+++ b/src/tests/model_tests.rs
@@ -1,5 +1,5 @@
 use crate::model::{
-    events::{Event, EventBuilder, EventInstance},
+    events::{EventBuilder, EventInstance},
     resources::Resource,
     slots::{Outline, Slot},
 };

--- a/src/tests/model_tests.rs
+++ b/src/tests/model_tests.rs
@@ -8,7 +8,7 @@ use crate::model::{
 
 #[test]
 pub fn event_errors_with_wrong_constraints() {
-    let event = EventBuilder::new(1, Duration::minutes(30))
+    let event = EventBuilder::new(1)
         .resource_constraints(vec![Resource::new(1, Outline::from(vec![Slot::new(1)]))])
         .build();
 
@@ -19,7 +19,7 @@ pub fn event_errors_with_wrong_constraints() {
 
 #[test]
 pub fn event_assigns_with_constraints() {
-    let event = EventBuilder::new(1, Duration::minutes(30))
+    let event = EventBuilder::new(1)
         .resource_constraints(vec![Resource::new(1, Outline::from(vec![Slot::new(1)]))])
         .build();
 

--- a/src/tests/model_tests.rs
+++ b/src/tests/model_tests.rs
@@ -1,0 +1,65 @@
+use chrono::{DateTime, Duration, TimeZone, Utc};
+
+use crate::model::{
+    events::{Event, EventBuilder, EventInstance},
+    resources::Resource,
+    slots::{Outline, Slot},
+};
+
+#[test]
+pub fn event_errors_with_wrong_constraints() {
+    let event = EventBuilder::new(1, Duration::minutes(30))
+        .resource_constraints(vec![Resource::new(
+            1,
+            Outline::from(vec![Slot::new(
+                Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
+                Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
+            )]),
+        )])
+        .build();
+
+    let res = event.assign(vec![Resource::new(
+        2,
+        Outline::from(vec![Slot::new(
+            Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
+            Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
+        )]),
+    )]);
+
+    assert_eq!(res, Err(()));
+}
+
+#[test]
+pub fn event_assigns_with_constraints() {
+    let event = EventBuilder::new(1, Duration::minutes(30))
+        .resource_constraints(vec![Resource::new(
+            1,
+            Outline::from(vec![Slot::new(
+                Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
+                Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
+            )]),
+        )])
+        .build();
+
+    let res = event.clone().assign(vec![Resource::new(
+        1,
+        Outline::from(vec![Slot::new(
+            Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
+            Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
+        )]),
+    )]);
+
+    assert_eq!(
+        res,
+        Ok(EventInstance {
+            event: event,
+            assigned_resources: vec![Resource::new(
+                1,
+                Outline::from(vec![Slot::new(
+                    Utc.with_ymd_and_hms(2023, 7, 18, 17, 55, 39).unwrap(),
+                    Utc.with_ymd_and_hms(2023, 7, 18, 18, 55, 39).unwrap(),
+                )],)
+            )],
+        })
+    );
+}

--- a/src/tests/model_tests.rs
+++ b/src/tests/model_tests.rs
@@ -1,5 +1,3 @@
-use chrono::{DateTime, Duration, TimeZone, Utc};
-
 use crate::model::{
     events::{Event, EventBuilder, EventInstance},
     resources::Resource,

--- a/src/tests/model_tests.rs
+++ b/src/tests/model_tests.rs
@@ -10,7 +10,10 @@ pub fn event_errors_with_wrong_constraints() {
         .resource_constraints(vec![Resource::new(1, Outline::from(vec![Slot::new(1)]))])
         .build();
 
-    let res = event.assign(vec![Resource::new(2, Outline::from(vec![Slot::new(2)]))]);
+    let res = event.assign(
+        Slot::new(1),
+        vec![Resource::new(2, Outline::from(vec![Slot::new(2)]))],
+    );
 
     assert_eq!(res, Err(()));
 }
@@ -21,14 +24,16 @@ pub fn event_assigns_with_constraints() {
         .resource_constraints(vec![Resource::new(1, Outline::from(vec![Slot::new(1)]))])
         .build();
 
-    let res = event
-        .clone()
-        .assign(vec![Resource::new(1, Outline::from(vec![Slot::new(1)]))]);
+    let res = event.clone().assign(
+        Slot::new(1),
+        vec![Resource::new(1, Outline::from(vec![Slot::new(1)]))],
+    );
 
     assert_eq!(
         res,
         Ok(EventInstance {
             event: event,
+            assigned_slot: Slot::new(1),
             assigned_resources: vec![Resource::new(1, Outline::from(vec![Slot::new(1)],))],
         })
     );


### PR DESCRIPTION
The main changes here reflect a conceptual shift from associating the events and slots with particular time and length to lack of such association, as it was deemed unnecessary and needlessly complicated the task. There were also changes improving quality of code like adding tests, removing unused imports and boilerplate files.

The changes here:
- Remove time-related attributes from Event and Slot
- Refactor EventInstance to have an assigned slot
- Remove PopulatedSlot since EventInstance's assigned slot now serves its purpose
- Clean up unused imports
- Remove chrono from the dependency list
- Remove example_tests